### PR TITLE
Update OCMockObject.m

### DIFF
--- a/Source/OCMock.xcodeproj/project.pbxproj
+++ b/Source/OCMock.xcodeproj/project.pbxproj
@@ -181,6 +181,8 @@
 		2FA28FEAEF9333D2C214DF53 /* NSValue+OCMAdditions.m in Sources */ = {isa = PBXBuildFile; fileRef = 2FA28896E5EEFD7C2F12C2F8 /* NSValue+OCMAdditions.m */; };
 		3C0FF06A1BAA3FD10021AD20 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F370CA1BAA1DE800CAD3E8 /* OCMFunctionsPrivate.h */; };
 		3C0FF06B1BAA3FD20021AD20 /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F370CA1BAA1DE800CAD3E8 /* OCMFunctionsPrivate.h */; };
+		3C76716C1BB3EBC500FDC9F4 /* TestClassWithCustomReferenceCounting.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CFBDD761BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
+		3CFBDD771BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.m in Sources */ = {isa = PBXBuildFile; fileRef = 3CFBDD761BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
 		817EB1661BD7674D0047E85A /* OCMFunctionsPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 03F370CA1BAA1DE800CAD3E8 /* OCMFunctionsPrivate.h */; };
 		D31108BA1828DB8700737925 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D31108B81828DB8700737925 /* InfoPlist.strings */; };
 		D31108C41828DBD600737925 /* OCMockObjectPartialMocksTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 03AC5C1416DF9FA500D82ECD /* OCMockObjectPartialMocksTests.m */; };
@@ -375,6 +377,8 @@
 		2FA28EC49F6C59B940AE6D00 /* OCMFunctions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OCMFunctions.h; sourceTree = "<group>"; };
 		2FA28EDBF243639C57F88A1B /* OCMArgTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMArgTests.m; sourceTree = "<group>"; };
 		2FA28EE3142412BD601026EF /* OCMockObjectDynamicPropertyMockingTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = OCMockObjectDynamicPropertyMockingTests.m; sourceTree = "<group>"; };
+		3CFBDD751BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TestClassWithCustomReferenceCounting.h; sourceTree = "<group>"; };
+		3CFBDD761BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TestClassWithCustomReferenceCounting.m; sourceTree = "<group>"; };
 		D31108AD1828DB8700737925 /* OCMockLibTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OCMockLibTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D31108B71828DB8700737925 /* OCMockLibTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "OCMockLibTests-Info.plist"; sourceTree = "<group>"; };
 		D31108B91828DB8700737925 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -533,6 +537,8 @@
 				03B316291463350E0052CD09 /* OCObserverMockObjectTests.m */,
 				03B3161F1463350E0052CD09 /* NSInvocationOCMAdditionsTests.m */,
 				2FA28DEDB9163597B7C49F3D /* NSMethodSignatureOCMAdditionsTests.m */,
+				3CFBDD751BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.h */,
+				3CFBDD761BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.m */,
 				03565A3418F0566F003AE91E /* Supporting Files */,
 			);
 			path = OCMockTests;
@@ -1097,6 +1103,7 @@
 				03565A4418F05721003AE91E /* OCMockObjectProtocolMocksTests.m in Sources */,
 				03565A4B18F05721003AE91E /* NSInvocationOCMAdditionsTests.m in Sources */,
 				03565A4618F05721003AE91E /* OCMockObjectHamcrestTests.mm in Sources */,
+				3CFBDD771BB3DB200050D9C5 /* TestClassWithCustomReferenceCounting.m in Sources */,
 				03E98D5018F310EE00522D42 /* OCMockObjectMacroTests.m in Sources */,
 				03565A4A18F05721003AE91E /* OCObserverMockObjectTests.m in Sources */,
 				03565A4318F05721003AE91E /* OCMockObjectClassMethodMockingTests.m in Sources */,
@@ -1118,6 +1125,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C76716C1BB3EBC500FDC9F4 /* TestClassWithCustomReferenceCounting.m in Sources */,
 				031E50591BB4A56300E257C3 /* OCMBoxedReturnValueProviderTests.m in Sources */,
 				03C9CA1E18F05A84006DF94D /* OCMArgTests.m in Sources */,
 				0322DA66191188D100CACAF1 /* OCMockObjectVerifyAfterRunTests.m in Sources */,

--- a/Source/OCMock/NSInvocation+OCMAdditions.h
+++ b/Source/OCMock/NSInvocation+OCMAdditions.h
@@ -19,8 +19,7 @@
 @interface NSInvocation(OCMAdditions)
 
 + (NSInvocation *)invocationForBlock:(id)block withArguments:(NSArray *)arguments;
-
-- (BOOL)hasCharPointerArgument;
+- (NSInvocation *)invocationByRemovingCStringsAndObject:(id)objectToExclude;
 
 - (id)getArgumentAtIndexAsObject:(NSInteger)argIndex;
 

--- a/Source/OCMock/OCMFunctions.m
+++ b/Source/OCMock/OCMFunctions.m
@@ -61,6 +61,16 @@ BOOL OCMIsObjectType(const char *objCType)
     return NO;
 }
 
+BOOL OCMIsCStringType(const char *objCType)
+{
+    return *OCMTypeWithoutQualifiers(objCType) == '*';
+}
+
+BOOL OCMIsVoidType(const char *objCType)
+{
+    return *OCMTypeWithoutQualifiers(objCType) == 'v';
+}
+
 
 const char *OCMTypeWithoutQualifiers(const char *objCType)
 {

--- a/Source/OCMock/OCMFunctionsPrivate.h
+++ b/Source/OCMock/OCMFunctionsPrivate.h
@@ -28,7 +28,8 @@
 @class OCPartialMockObject;
 
 
-OCMOCK_EXTERN BOOL OCMIsObjectType(const char *objCType);
+OCMOCK_EXTERN BOOL OCMIsVoidType(const char *objCType);
+OCMOCK_EXTERN BOOL OCMIsCStringType(const char *objCType);
 const char *OCMTypeWithoutQualifiers(const char *objCType);
 BOOL OCMEqualTypesAllowingOpaqueStructs(const char *type1, const char *type2);
 CFNumberType OCMNumberTypeForObjCType(const char *objcType);

--- a/Source/OCMock/OCMock.h
+++ b/Source/OCMock/OCMock.h
@@ -42,8 +42,13 @@
 ({ \
     _OCMSilenceWarnings( \
         [OCMMacroState beginStubMacro]; \
-        invocation; \
-        [OCMMacroState endStubMacro]; \
+        OCMStubRecorder *recorder = nil; \
+        @try{ \
+            invocation; \
+        }@finally{ \
+            recorder = [OCMMacroState endStubMacro]; \
+        } \
+        recorder; \
     ); \
 })
 
@@ -51,8 +56,13 @@
 ({ \
     _OCMSilenceWarnings( \
         [OCMMacroState beginExpectMacro]; \
-        invocation; \
-        [OCMMacroState endExpectMacro]; \
+        OCMStubRecorder *recorder = nil; \
+        @try{ \
+            invocation; \
+        }@finally{ \
+            recorder = [OCMMacroState endExpectMacro]; \
+        } \
+        recorder; \
     ); \
 })
 
@@ -71,8 +81,11 @@
 ({ \
     _OCMSilenceWarnings( \
         [OCMMacroState beginVerifyMacroAtLocation:OCMMakeLocation(self, __FILE__, __LINE__)]; \
-        invocation; \
-        [OCMMacroState endVerifyMacro]; \
+        @try{ \
+            invocation; \
+        }@finally{ \
+            [OCMMacroState endVerifyMacro]; \
+        } \
     ); \
 })
 

--- a/Source/OCMock/OCMockObject.h
+++ b/Source/OCMock/OCMockObject.h
@@ -30,7 +30,7 @@
 	NSMutableArray	*stubs;
 	NSMutableArray	*expectations;
 	NSMutableArray	*exceptions;
-    NSMutableArray  *invocations;
+    NSMapTable      *invocations;
 }
 
 + (id)mockForClass:(Class)aClass;

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -93,7 +93,7 @@
 	stubs = [[NSMutableArray alloc] init];
 	expectations = [[NSMutableArray alloc] init];
 	exceptions = [[NSMutableArray alloc] init];
-    invocations = [[NSMutableArray alloc] init];
+    invocations = [[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableStrongMemory capacity:0];
     return self;
 }
 
@@ -113,12 +113,18 @@
 
 - (void)addStub:(OCMInvocationStub *)aStub
 {
-    [stubs addObject:aStub];
+    @synchronized(stubs)
+    {
+        [stubs addObject:aStub];
+    }
 }
 
 - (void)addExpectation:(OCMInvocationExpectation *)anExpectation
 {
-    [expectations addObject:anExpectation];
+    @synchronized(expectations)
+    {
+        [expectations addObject:anExpectation];
+    }
 }
 
 
@@ -159,10 +165,13 @@
 - (id)verifyAtLocation:(OCMLocation *)location
 {
     NSMutableArray *unsatisfiedExpectations = [NSMutableArray array];
-    for(OCMInvocationExpectation *e in expectations)
+    @synchronized(expectations)
     {
-        if(![e isSatisfied])
-            [unsatisfiedExpectations addObject:e];
+        for(OCMInvocationExpectation *e in expectations)
+        {
+            if(![e isSatisfied])
+                [unsatisfiedExpectations addObject:e];
+        }
     }
 
 	if([unsatisfiedExpectations count] == 1)
@@ -178,12 +187,18 @@
         OCMReportFailure(location, description);
 	}
 
-	if([exceptions count] > 0)
+    OCMInvocationExpectation *firstException = nil;
+    @synchronized(exceptions)
+    {
+        firstException = [exceptions.firstObject retain];
+    }
+    if(firstException)
 	{
         NSString *description = [NSString stringWithFormat:@"%@: %@ (This is a strict mock failure that was ignored when it actually occured.)",
-         [self description], [[exceptions objectAtIndex:0] description]];
+         [self description], [firstException description]];
         OCMReportFailure(location, description);
 	}
+    [firstException release];
 
     return [[[OCMVerifier alloc] initWithMockObject:self] autorelease];
 }
@@ -199,8 +214,11 @@
     NSTimeInterval step = 0.01;
     while(delay > 0)
     {
-        if([expectations count] == 0)
-            break;
+        @synchronized(expectations)
+        {
+            if([expectations count] == 0)
+                break;
+        }
         [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:step]];
         delay -= step;
         step *= 2;
@@ -218,10 +236,13 @@
 
 - (void)verifyInvocation:(OCMInvocationMatcher *)matcher atLocation:(OCMLocation *)location
 {
-    for(NSInvocation *invocation in invocations)
+    @synchronized(invocations)
     {
-        if([matcher matchesInvocation:invocation])
-            return;
+        for(NSInvocation *invocation in invocations)
+        {
+            if([matcher matchesInvocation:invocation])
+                return;
+        }
     }
     NSString *description = [NSString stringWithFormat:@"%@: Method %@ was not invoked.",
      [self description], [matcher description]];
@@ -246,10 +267,12 @@
 
 - (BOOL)handleSelector:(SEL)sel
 {
-    for(OCMInvocationStub *recorder in stubs)
-        if([recorder matchesSelector:sel])
-            return YES;
-
+    @synchronized(stubs)
+    {
+        for(OCMInvocationStub *recorder in stubs)
+            if([recorder matchesSelector:sel])
+                return YES;
+    }
     return NO;
 }
 
@@ -269,7 +292,10 @@
         else
         {
             // add non-stubbed method to list of exceptions to be re-raised in verify
-            [exceptions addObject:e];
+            @synchronized(exceptions)
+            {
+                [exceptions addObject:e];
+            }
         }
         [e raise];
     }
@@ -277,43 +303,67 @@
 
 - (BOOL)handleInvocation:(NSInvocation *)anInvocation
 {
-    [invocations addObject:anInvocation];
-
-    OCMInvocationStub *stub = nil;
-    for(stub in stubs)
+    @synchronized(invocations)
     {
-        // If the stub forwards its invocation to the real object, then we don't want to do handleInvocation: yet, since forwarding the invocation to the real object could call a method that is expected to happen after this one, which is bad if expectationOrderMatters is YES
-        if([stub matchesInvocation:anInvocation])
-            break;
+        // We can't retain arguments on anInvocation because its target/arguments/return value could be
+        // self. That would produce a retain cycle self->invocations->anInvocation->self. However we
+        // need to retain everything on anInvocation that isn't self because we expect them to stick
+        // around after this method returns. Make a copy of anInvocation to hold onto that doesn't
+        // contain any references to self.
+        NSInvocation *selflessInvocation = [anInvocation invocationByRemovingCStringsAndObject:self];
+        [selflessInvocation retainArguments];
+        [invocations setObject:selflessInvocation forKey:anInvocation];
     }
-    // Retain the stub in case it ends up being removed from stubs and expectations, since we still have to call handleInvocation on the stub at the end
-    [stub retain];
+    
+    OCMInvocationStub *stub = nil;
+    @synchronized(stubs)
+    {
+        for(stub in stubs)
+        {
+            // If the stub forwards its invocation to the real object, then we don't want to do handleInvocation: yet, since forwarding the invocation to the real object could call a method that is expected to happen after this one, which is bad if expectationOrderMatters is YES
+            if([stub matchesInvocation:anInvocation])
+                break;
+        }
+        // Retain the stub in case it ends up being removed from stubs and expectations, since we still have to call handleInvocation on the stub at the end
+        [stub retain];
+    }
     if(stub == nil)
         return NO;
-
-     if([expectations containsObject:stub])
-     {
-          OCMInvocationExpectation *expectation = [self _nextExpectedInvocation];
-          if(expectationOrderMatters && (expectation != stub))
-          {
-               [NSException raise:NSInternalInconsistencyException format:@"%@: unexpected method invoked: %@\n\texpected:\t%@",
-                            [self description], [stub description], [[expectations objectAtIndex:0] description]];
-          }
-
-          // We can't check isSatisfied yet, since the stub won't be satisfied until we call handleInvocation:, and we don't want to call handleInvocation: yes for the reason in the comment above, since we'll still have the current expectation in the expectations array, which will cause an exception if expectationOrderMatters is YES and we're not ready for any future expected methods to be called yet
-          if(![(OCMInvocationExpectation *)stub isMatchAndReject])
-          {
-               [expectations removeObject:stub];
-               [stubs removeObject:stub];
-          }
-     }
-     [stub handleInvocation:anInvocation];
-     [stub release];
-
-     return YES;
+    
+    BOOL removeStub = NO;
+    @synchronized(expectations)
+    {
+        if([expectations containsObject:stub])
+        {
+            OCMInvocationExpectation *expectation = [self _nextExpectedInvocation];
+            if(expectationOrderMatters && (expectation != stub))
+            {
+                [NSException raise:NSInternalInconsistencyException format:@"%@: unexpected method invoked: %@\n\texpected:\t%@",
+                             [self description], [stub description], [[expectations objectAtIndex:0] description]];
+            }
+            
+            // We can't check isSatisfied yet, since the stub won't be satisfied until we call handleInvocation:, and we don't want to call handleInvocation: yes for the reason in the comment above, since we'll still have the current expectation in the expectations array, which will cause an exception if expectationOrderMatters is YES and we're not ready for any future expected methods to be called yet
+            if(![(OCMInvocationExpectation *)stub isMatchAndReject])
+            {
+                [expectations removeObject:stub];
+                removeStub = YES;
+            }
+        }
+    }
+    if(removeStub)
+    {
+        @synchronized(stubs)
+        {
+            [stubs removeObject:stub];
+        }
+    }
+    [stub handleInvocation:anInvocation];
+    [stub release];
+    
+    return YES;
 }
 
-
+// Must be synchronized on expectations when calling this method.
 - (OCMInvocationExpectation *)_nextExpectedInvocation
 {
     for(OCMInvocationExpectation *expectation in expectations)
@@ -352,24 +402,36 @@
 - (NSString *)_stubDescriptions:(BOOL)onlyExpectations
 {
 	NSMutableString *outputString = [NSMutableString string];
-    for(OCMStubRecorder *stub in stubs)
+    NSArray *stubsCopy = nil;
+    @synchronized(stubs)
     {
+        stubsCopy = [stubs copy];
+    }
+    for(OCMStubRecorder *stub in stubsCopy)
+    {
+        BOOL expectationsContainStub = NO;
+        @synchronized(expectations)
+        {
+            expectationsContainStub = [expectations containsObject:stub];
+        }
+        
 		NSString *prefix = @"";
 		
 		if(onlyExpectations)
 		{
-			if([expectations containsObject:stub] == NO)
+			if(expectationsContainStub == NO)
 				continue;
 		}
 		else
 		{
-			if([expectations containsObject:stub])
+			if(expectationsContainStub)
 				prefix = @"expected:\t";
 			else
 				prefix = @"stubbed:\t";
 		}
 		[outputString appendFormat:@"\n\t%@%@", prefix, [stub description]];
 	}
+    [stubsCopy release];
 	return outputString;
 }
 

--- a/Source/OCMock/OCMockObject.m
+++ b/Source/OCMock/OCMockObject.m
@@ -93,7 +93,7 @@
 	stubs = [[NSMutableArray alloc] init];
 	expectations = [[NSMutableArray alloc] init];
 	exceptions = [[NSMutableArray alloc] init];
-    invocations = [[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory valueOptions:NSMapTableStrongMemory capacity:0];
+    invocations = [[NSMapTable alloc] initWithKeyOptions:NSMapTableStrongMemory | NSMapTableObjectPointerPersonality valueOptions:NSMapTableStrongMemory capacity:0];
     return self;
 }
 

--- a/Source/OCMock/OCObserverMockObject.m
+++ b/Source/OCMock/OCObserverMockObject.m
@@ -61,7 +61,10 @@
 
 - (void)autoRemoveFromCenter:(NSNotificationCenter *)aCenter
 {
-    [centers addObject:aCenter];
+    @synchronized(centers)
+    {
+        [centers addObject:aCenter];
+    }
 }
 
 
@@ -70,7 +73,10 @@
 - (id)expect
 {
 	OCMObserverRecorder *recorder = [[[OCMObserverRecorder alloc] init] autorelease];
-	[recorders addObject:recorder];
+    @synchronized(recorders)
+    {
+        [recorders addObject:recorder];
+    }
 	return recorder;
 }
 
@@ -81,17 +87,20 @@
 
 - (void)verifyAtLocation:(OCMLocation *)location
 {
-    if([recorders count] == 1)
+    @synchronized(recorders)
     {
-        NSString *description = [NSString stringWithFormat:@"%@: expected notification was not observed: %@",
-         [self description], [[recorders lastObject] description]];
-        OCMReportFailure(location, description);
-    }
-    else if([recorders count] > 0)
-    {
-        NSString *description = [NSString stringWithFormat:@"%@ : %@ expected notifications were not observed.",
-         [self description], @([recorders count])];
-        OCMReportFailure(location, description);
+        if([recorders count] == 1)
+        {
+            NSString *description = [NSString stringWithFormat:@"%@: expected notification was not observed: %@",
+             [self description], [[recorders lastObject] description]];
+            OCMReportFailure(location, description);
+        }
+        else if([recorders count] > 0)
+        {
+            NSString *description = [NSString stringWithFormat:@"%@ : %@ expected notifications were not observed.",
+             [self description], @([recorders count])];
+            OCMReportFailure(location, description);
+        }
     }
 }
 
@@ -108,18 +117,21 @@
 
 - (void)handleNotification:(NSNotification *)aNotification
 {
-	NSUInteger i, limit;
-	
-	limit = expectationOrderMatters ? 1 : [recorders count];
-	for(i = 0; i < limit; i++)
-	{
-		if([[recorders objectAtIndex:i] matchesNotification:aNotification])
-		{
-			[recorders removeObjectAtIndex:i];
-			return;
-		}
-	}
-	[NSException raise:NSInternalInconsistencyException format:@"%@: unexpected notification observed: %@", [self description], 
+    @synchronized(recorders)
+    {
+        NSUInteger i, limit;
+        
+        limit = expectationOrderMatters ? 1 : [recorders count];
+        for(i = 0; i < limit; i++)
+        {
+            if([[recorders objectAtIndex:i] matchesNotification:aNotification])
+            {
+                [recorders removeObjectAtIndex:i];
+                return;
+            }
+        }
+    }
+	[NSException raise:NSInternalInconsistencyException format:@"%@: unexpected notification observed: %@", [self description],
 	  [aNotification description]];
 }
 

--- a/Source/OCMock/OCPartialMockObject.m
+++ b/Source/OCMock/OCPartialMockObject.m
@@ -127,7 +127,7 @@
 
     /* Adding forwarder for most instance methods to allow for verify after run */
     NSArray *methodBlackList = @[@"class", @"forwardingTargetForSelector:", @"methodSignatureForSelector:", @"forwardInvocation:",
-            @"allowsWeakReference", @"retainWeakReference", @"isBlock"];
+            @"allowsWeakReference", @"retainWeakReference", @"isBlock", @"retainCount", @"retain", @"release", @"autorelease"];
     [NSObject enumerateMethodsInClass:mockedClass usingBlock:^(Class cls, SEL sel) {
         if((cls == [NSObject class]) || (cls == [NSProxy class]))
             return;

--- a/Source/OCMockTests/OCMockObjectPartialMocksTests.m
+++ b/Source/OCMockTests/OCMockObjectPartialMocksTests.m
@@ -18,6 +18,8 @@
 #import <OCMock/OCMock.h>
 #import <objc/runtime.h>
 
+#import "TestClassWithCustomReferenceCounting.h"
+
 #if TARGET_OS_IPHONE
 #define NSRect CGRect
 #define NSZeroRect CGRectZero
@@ -264,6 +266,16 @@ static NSUInteger initializeCallCount = 0;
     XCTAssertThrows(OCMPartialMock(nil));
 }
 
+- (void)testPartialMockOfCustomReferenceCountingObject
+{
+    /* The point of using an object that implements its own reference counting methods is to force
+       -retain to be called even though the test is compiled with ARC. (Normally ARC does some magic
+       that bypasses dispatching to -retain.) Issue #245 turned up a recursive crash when partial
+       mocks used a forwarder for -retain. */
+    TestClassWithCustomReferenceCounting *realObject = [TestClassWithCustomReferenceCounting new];
+    id partialMock = OCMPartialMock(realObject);
+    XCTAssertNotNil(partialMock);
+}
 
 #pragma mark   Tests for KVO interaction with mocks
 

--- a/Source/OCMockTests/TestClassWithCustomReferenceCounting.h
+++ b/Source/OCMockTests/TestClassWithCustomReferenceCounting.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2014-2015 Erik Doernenburg and contributors
+ *  Copyright (c) 2015 Erik Doernenburg and contributors
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
  *  not use these files except in compliance with the License. You may obtain
@@ -16,23 +16,5 @@
 
 #import <Foundation/Foundation.h>
 
-@interface OCMInvocationMatcher : NSObject
-{
-    NSInvocation *recordedInvocation;
-    NSInvocation *retainedArgumentsInvocation;
-    BOOL         recordedAsClassMethod;
-    BOOL         ignoreNonObjectArgs;
-}
-
-- (void)setInvocation:(NSInvocation *)anInvocation;
-- (NSInvocation *)recordedInvocation;
-
-- (void)setRecordedAsClassMethod:(BOOL)flag;
-- (BOOL)recordedAsClassMethod;
-
-- (void)setIgnoreNonObjectArgs:(BOOL)flag;
-
-- (BOOL)matchesSelector:(SEL)aSelector;
-- (BOOL)matchesInvocation:(NSInvocation *)anInvocation;
-
+@interface TestClassWithCustomReferenceCounting : NSObject
 @end

--- a/Source/OCMockTests/TestClassWithCustomReferenceCounting.m
+++ b/Source/OCMockTests/TestClassWithCustomReferenceCounting.m
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2015 Erik Doernenburg and contributors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use these files except in compliance with the License. You may obtain
+ *  a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ *  License for the specific language governing permissions and limitations
+ *  under the License.
+ */
+
+#import "TestClassWithCustomReferenceCounting.h"
+
+#import <libkern/OSAtomic.h>
+
+@implementation TestClassWithCustomReferenceCounting
+{
+    int32_t retainCount;
+}
+
+- (NSUInteger)retainCount
+{
+    return retainCount + 1;
+}
+
+- (instancetype)retain
+{
+    OSAtomicIncrement32(&retainCount);
+    return self;
+}
+
+- (oneway void)release
+{
+    int32_t newRetainCount = OSAtomicDecrement32(&retainCount);
+    if (newRetainCount == -1)
+        [self dealloc];
+}
+
+@end


### PR DESCRIPTION
Our tests were failing because invocations were not recorded if the selectors matched, but the arguments didn't. Apparently [NSInvocation isEqual:] doesn't do a deep equality check.